### PR TITLE
Fix; Failing CI build on`rolling`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - IMAGE: rolling-source
+          - IMAGE: [jazzy-release, main-jazzy-tutorial-source]
 
     env:
       DOCKER_IMAGE: moveit/moveit2:${{ matrix.env.IMAGE }}
@@ -33,7 +33,7 @@ jobs:
       CACHE_PREFIX: ${{ matrix.env.IMAGE }}
 
     name: ${{ matrix.env.IMAGE }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
# Description

As I've been testing to fix CI failure on `moveit2_tutorials`, I noticed https://github.com/moveit/moveit2_tutorials/pull/1072 is not failing except "ci" job. This PR is to fix that.

## Rationale
In https://github.com/moveit/moveit2_tutorials/issues/1033#issuecomment-4735722259 the maintainers (incl. myself) mentioned the interest to switch the focus to have `jazzy` build for now on `moveit2_tutorials` repo. So switching the CI to use `jazzy` as a prebuilt Docker image.

# Plan after this PR merged
1. Branches: This PR targets the branch on this forked repo that is used in  https://github.com/moveit/moveit2_tutorials/pull/1072
1. Once this PR is merged, the mentioned PR will be updated with the change in this PR. 
1. Have that PR merged. By that time CI on `moveit/moveit2_tutorials` will be green again, hopefully.

